### PR TITLE
Update MCP3221.ino

### DIFF
--- a/examples/MCP3221/MCP3221.ino
+++ b/examples/MCP3221/MCP3221.ino
@@ -13,6 +13,7 @@ void setup() {
     Wire.begin(SDA, SCL);
     mcp3221.init(&Wire);
 #else
+    Wire.begin();
     mcp3221.init();
 #endif
 }


### PR DESCRIPTION
Fixes sensor not working on arduino uno. (always returns 65535)